### PR TITLE
release: change the order of operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ test:
 
 release:
 	./release
-	goreleaser release --rm-dist
 	git push
+	goreleaser release --rm-dist
 
 install:
 	go install  ${LDFLAGS} .


### PR DESCRIPTION
release vX+1 will include that of vX in the changelog:
```
Changelog
8bae604 release version 0.2.3
7446f03 clarify ssh-config (#34)
d89a64d release version 0.2.2
```