### PR TITLE
Add okta-add command to setup Okta credentials

### DIFF
--- a/cmd/okta-setup.go
+++ b/cmd/okta-setup.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/99designs/keyring"
+	"github.com/chanzuckerberg/blessclient/pkg/config"
+	"github.com/chanzuckerberg/blessclient/pkg/util"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pkg/errors"
+	awsokta "github.com/segmentio/aws-okta/lib"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(oktaSetupCmd)
+}
+
+var oktaSetupCmd = &cobra.Command{
+	Use:           "okta-setup",
+	Short:         "okta-setup sets up Okta login credentials",
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		expandedConfigFile, err := util.GetConfigPath(cmd)
+		if err != nil {
+			return err
+		}
+		log.Debugf("Reading config from %s", expandedConfigFile)
+		conf, err := config.FromFile(expandedConfigFile)
+		if err != nil {
+			return err
+		}
+		log.Debugf("Parsed config is: %s", spew.Sdump(conf))
+
+		if conf.OktaConfig == nil {
+			return errors.Errorf("The okta_config section is not found in your config")
+		}
+
+		kr, err := awsokta.OpenKeyring(nil)
+		if err != nil {
+			return err
+		}
+		username, err := awsokta.Prompt("Okta username", false)
+		if err != nil {
+			return err
+		}
+
+		password, err := awsokta.Prompt("Okta password", true)
+		if err != nil {
+			return err
+		}
+		fmt.Println()
+
+		organization := conf.OktaConfig.Organization
+		domain := conf.OktaConfig.Domain
+
+		creds := awsokta.OktaCreds{
+			Organization: organization,
+			Username:     username,
+			Password:     password,
+			Domain:       domain,
+		}
+
+		mfaDevice := "phone1"
+		if conf.OktaConfig.MFADevice != nil {
+			mfaDevice = *conf.OktaConfig.MFADevice
+		}
+		if err := creds.Validate(mfaDevice); err != nil {
+			return errors.Wrap(err, "Failed to verify Okta credentials")
+		}
+
+		encoded, err := json.Marshal(creds)
+		if err != nil {
+			return err
+		}
+
+		item := keyring.Item{
+			Key:                         "okta-creds",
+			Data:                        encoded,
+			Label:                       "okta credentials",
+			KeychainNotTrustApplication: false,
+		}
+
+		if err := kr.Set(item); err != nil {
+			return errors.Wrap(err, "Failed to save credentials in credential store")
+		}
+
+		log.Infof("Added credentials for user %s", username)
+		return nil
+	},
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,8 +84,10 @@ type ClientConfig struct {
 
 // OktaConfig is the Okta config
 type OktaConfig struct {
-	Profile   string  `yaml:"profile"`
-	MFADevice *string `yaml:"mfa_device,omitempty"`
+	Domain       string  `yaml:"domain"`
+	Organization string  `yaml:"organization"`
+	Profile      string  `yaml:"profile"`
+	MFADevice    *string `yaml:"mfa_device,omitempty"`
 }
 
 // LambdaConfig is the lambda config

--- a/pkg/util/github.go
+++ b/pkg/util/github.go
@@ -12,7 +12,7 @@ import (
 func CheckLatestVersion(ctx context.Context, owner string, repo string) error {
 	err := checkLatestVersion(ctx, owner, repo)
 	if err != nil {
-		logrus.WithError(err).WithField("repo", fmt.Sprintf("%s/%s", owner, repo)).Warn("Could not fetch latest release info")
+		logrus.WithError(err).WithField("repo", fmt.Sprintf("%s/%s", owner, repo)).Debug("Could not fetch latest release info")
 		return err
 	}
 	return nil


### PR DESCRIPTION
Changes:

* Added a command to add your Okta username and password to the keyring. This is the same command as https://github.com/segmentio/aws-okta/blob/master/cmd/add.go. I added it here so that users don't need to install aws-okta just for the `add` command to setup their Okta credentials. The reason why we can't store Okta username and password in the config is because passwords should not be stored in plaintext, and using this shared code from aws-okta enables us to store it in the keyring. (Alternative solution considered: storing the password as encrypted blob in the config. Not super user friendly.)
* A slightly contentious change: I changed the `CheckLatestVersion` error to Debug. Not sure how important this is to show as a warning, but see the before and after screenshots below. Happy to change this if you have a better alternative! Unfortunately the "Requesting MFA. Please complete..." steps are [INFO] level, so I can't just set the log level to ERROR.

![screen shot 2018-12-14 at 10 40 29 am](https://user-images.githubusercontent.com/2908189/50021276-6a147f80-ff8d-11e8-8112-47e5257e7170.png)

![screen shot 2018-12-14 at 10 41 12 am](https://user-images.githubusercontent.com/2908189/50021293-78629b80-ff8d-11e8-80b9-24baccba44e6.png)

