### PR TITLE
Ensure that the IsCertFresh function checks expected remote usernames

### DIFF
--- a/pkg/bless/client.go
+++ b/pkg/bless/client.go
@@ -87,7 +87,7 @@ func (c *Client) RequestCert(ctx context.Context) error {
 
 	payload := &LambdaPayload{
 		BastionUser:     c.username,
-		RemoteUsernames: strings.Join(c.conf.GetRemoteUsers(ctx, c.username), ","),
+		RemoteUsernames: strings.Join(c.conf.GetRemoteUsers(c.username), ","),
 		BastionIPs:      strings.Join(c.conf.ClientConfig.BastionIPS, ","),
 		BastionUserIP:   "0.0.0.0/0",
 		Command:         "*",
@@ -101,7 +101,7 @@ func (c *Client) RequestCert(ctx context.Context) error {
 	// Check to see if ssh client version is compatible with the key type
 	s.CheckKeyTypeAndClientVersion(ctx)
 
-	isFresh, err := s.IsCertFresh(c.conf)
+	isFresh, err := s.IsCertFresh(c.conf, c.username)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -251,9 +251,7 @@ func (c *Config) GetAWSUsername(ctx context.Context, awsClient *cziAWS.Client) (
 
 // GetRemoteUsers gets the list of remote usernames, defaulting to the provided username if
 // the list of configured remote users is empty.
-func (c *Config) GetRemoteUsers(ctx context.Context, username string) []string {
-	ctx, span := trace.StartSpan(ctx, "get_remote_users")
-	defer span.End()
+func (c *Config) GetRemoteUsers(username string) []string {
 	log.Debugf("Getting remote usernames")
 	remoteUsers := c.ClientConfig.RemoteUsers
 	if len(remoteUsers) == 0 {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -176,7 +176,7 @@ func (ts *TestSuite) TestGetRemoteUsers() {
 	c, err := config.DefaultConfig()
 	a.Nil(err)
 
-	remoteUsers := c.GetRemoteUsers(ts.ctx, "testusername")
+	remoteUsers := c.GetRemoteUsers("testusername")
 	a.Equal([]string{"testusername"}, remoteUsers)
 }
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -120,7 +120,7 @@ func (s *SSH) ReadAndParseCert() (*ssh.Certificate, error) {
 }
 
 // IsCertFresh determines if the cert is still fresh
-func (s *SSH) IsCertFresh(c *config.Config) (bool, error) {
+func (s *SSH) IsCertFresh(c *config.Config, username string) (bool, error) {
 	cert, err := s.ReadAndParseCert()
 	if err != nil {
 		return false, err
@@ -139,7 +139,7 @@ func (s *SSH) IsCertFresh(c *config.Config) (bool, error) {
 	val, ok := cert.CriticalOptions["source-address"]
 	isFresh = isFresh && ok && val == strings.Join(c.ClientConfig.BastionIPS, ",")
 	// Compare principals
-	isFresh = isFresh && reflect.DeepEqual(cert.ValidPrincipals, c.ClientConfig.RemoteUsers)
+	isFresh = isFresh && reflect.DeepEqual(cert.ValidPrincipals, c.GetRemoteUsers(username))
 
 	return isFresh, nil
 }

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -195,7 +195,7 @@ func (ts *TestSuite) TestIsCertFreshExpiredCert() {
 		},
 	}
 	// no error no cert
-	fresh, err := s.IsCertFresh(conf)
+	fresh, err := s.IsCertFresh(conf, "username")
 	a.Nil(err)
 	a.False(fresh)
 }
@@ -215,7 +215,7 @@ func (ts *TestSuite) TestIsCertFreshNoCert() {
 		},
 	}
 	// no error no cert
-	fresh, err := s.IsCertFresh(conf)
+	fresh, err := s.IsCertFresh(conf, "username")
 	a.Nil(err)
 	a.False(fresh)
 }


### PR DESCRIPTION
As a follow-up to https://github.com/chanzuckerberg/blessclient/pull/89, we want to make sure the `IsCertFresh` function checks remote usernames using the new function rather than directly reading from the config.

I removed the ctx argument and also tracing because this is a simple getter that probably doesn't need it, but let me know if you have any suggestions.