### PR TITLE
Change warning to debug for OpenSSH 7.8 version warning

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -189,7 +189,7 @@ func (s *SSH) CheckKeyTypeAndClientVersion(ctx context.Context) {
 		}
 		span.AddAttributes(trace.StringAttribute("ssh_key_type", "rsa"), trace.Int64Attribute("ssh_key_size", int64(k.Size())))
 		if strings.Contains(version, "OpenSSH_7.8") {
-			logrus.Warn(`
+			logrus.Debug(`
 Looks like you are attempting to use an RSA key with OpenSSH_7.8.
 This might be an unsupported opperation.
 See: https://github.com/chanzuckerberg/blessclient#ssh-client-78-cant-connect-with-certificates`)

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/blessclient/pkg/config"
+	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -134,6 +135,7 @@ func (ts *TestSuite) TestCheckVersionErrorLogError() {
 }
 
 func (ts *TestSuite) TestCheckVersionRSA78() {
+	log.SetLevel(log.DebugLevel)
 	t := ts.T()
 	a := assert.New(t)
 	s, err := NewSSH(rsaPrivateKeyPath)
@@ -144,7 +146,7 @@ func (ts *TestSuite) TestCheckVersionRSA78() {
 	s.CheckKeyTypeAndClientVersion(context.Background())
 
 	found := false
-	for _, entry := range ts.loggerHook.AllEntries() {
+	for _, entry := range ts.loggerHook.Entries {
 
 		found = found || strings.Contains(entry.Message, "RSA key with OpenSSH_7.8")
 	}

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -144,7 +144,7 @@ func (ts *TestSuite) TestCheckVersionRSA78() {
 	s.CheckKeyTypeAndClientVersion(context.Background())
 
 	found := false
-	for _, entry := range ts.loggerHook.Entries {
+	for _, entry := range ts.loggerHook.AllEntries() {
 
 		found = found || strings.Contains(entry.Message, "RSA key with OpenSSH_7.8")
 	}


### PR DESCRIPTION
Alternative to https://github.com/chanzuckerberg/blessclient/pull/101