### PR TITLE
[breaking] Add more MFA config options for Okta

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ This ssh config does a couple of interesting things -
 - It transparently requests an ssh certificate if needed
 - It transparently does a ProxyJump through a bastion host (assuming 10.0.* is an ipblock for machines behind the bastion)
 
+### Enable Okta SSO
+
+By default, blessclient uses your IAM user credentials. Blessclient is able to support Okta SAML auth if this is [enabled for your AWS account](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service.html). The [example config](examples/config.yml) shows the configuration options available under `okta_config`. Blessclient uses the [aws-okta](https://github.com/segmentio/aws-okta) library for authentication, which supports multiple MFA options.
+
+You will need to setup a profile in your ~/.aws/config that can be accepted by aws-okta. Example configs are available [here](https://github.com/segmentio/aws-okta/tree/master#configuring-your-aws-config).
+
 ## Telemetry
 There currently is some basic trace instrumentation using [honeycomb](https://www.honeycomb.io/). We use this internally to track usage, gather performance statistics, and error reporting. Telemetry is disabled without a honeycomb write key - which you must provide through the [config](pkg/config/config.go).
 

--- a/cmd/okta-setup.go
+++ b/cmd/okta-setup.go
@@ -63,8 +63,8 @@ var oktaSetupCmd = &cobra.Command{
 			Domain:       domain,
 		}
 
-		mfaDevice := conf.GetOktaMFADevice()
-		if err = creds.Validate(mfaDevice); err != nil {
+		mfaConfig := conf.GetOktaMFAConfig()
+		if err = creds.Validate(mfaConfig); err != nil {
 			return errors.Wrap(err, "Failed to verify Okta credentials")
 		}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -183,9 +183,9 @@ func getAWSOktaCredentials(conf *config.Config) (*credentials.Value, error) {
 		return nil, errors.Errorf("Profile '%s' not found in your aws config", profile)
 	}
 
-	mfaDevice := conf.GetOktaMFADevice()
+	mfaConfig := conf.GetOktaMFAConfig()
 	opts := awsokta.ProviderOptions{
-		MFADevice:          mfaDevice,
+		MFAConfig:          mfaConfig,
 		Profiles:           profiles,
 		SessionDuration:    time.Hour,
 		AssumeRoleDuration: time.Hour,

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -40,8 +40,15 @@ lambda_config:
 okta_config:
   # the name of the profile to be used for aws-okta (profiles are listed at ~/.aws/config)
   profile: bless_profile
-  # optional, the mfa device to be used for Okta MFA verification
-  mfa_device: phone1
+  # optional, the MFA provider to be used for Okta MFA verification (e.g. Okta, DUO)
+  # defaults to DUO
+  mfa_provider: DUO
+  # optional, the factor type to be used for Okta MFA verification (e.g. sms, token, web)
+  # DUO requires the "web" factor type
+  mfa_factor_type: web
+  # optional, the Duo device to be used for Duo MFA verification (e.g. phone1, phone2, u2f)
+  # duo_device should only be set if the provider is "DUO"
+  duo_device: phone1
 # This will help you generate a ~/.ssh/config compatible with blessclient
 ssh_config:
   # If you have a bastion and other servers behind it then


### PR DESCRIPTION
This update https://github.com/segmentio/aws-okta/pull/108 was recently pushed to aws-okta/master, which enables a much better MFA configuration. I can't make this change directly here because aws-okta is forked. @edulop91 Can you pull master changes to the forked aws-okta?