### PR TITLE
Increase session duration

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -187,7 +187,7 @@ func getAWSOktaCredentials(conf *config.Config) (*credentials.Value, error) {
 	opts := awsokta.ProviderOptions{
 		MFAConfig:          mfaConfig,
 		Profiles:           profiles,
-		SessionDuration:    time.Hour,
+		SessionDuration:    time.Hour * 18,
 		AssumeRoleDuration: time.Hour,
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -187,7 +187,7 @@ func getAWSOktaCredentials(conf *config.Config) (*credentials.Value, error) {
 	opts := awsokta.ProviderOptions{
 		MFAConfig:          mfaConfig,
 		Profiles:           profiles,
-		SessionDuration:    time.Hour * 18,
+		SessionDuration:    time.Hour * 12,
 		AssumeRoleDuration: time.Hour,
 	}
 


### PR DESCRIPTION
I'm happy to make this configurable if you'd like, however I think this is a sane setting. This means the MFA'ed session is valid for 12 hours, which is good for one day of work.