### PR TITLE
Added functionality to specify the backend for aws-okta

### DIFF
--- a/cmd/okta-setup.go
+++ b/cmd/okta-setup.go
@@ -38,11 +38,11 @@ var oktaSetupCmd = &cobra.Command{
 			return errors.Errorf("The okta_config section is not found in your config")
 		}
 
-		kr, err := awsokta.OpenKeyring(nil)
+		kr, err := awsokta.OpenKeyring(conf.GetAWSOktaKeyringBackend())
 		if err != nil {
 			return err
 		}
-		username, err := awsokta.Prompt("Okta username", false)
+		username, err := awsokta.Prompt("Okta username (email address)", false)
 		if err != nil {
 			return err
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -191,7 +191,7 @@ func getAWSOktaCredentials(conf *config.Config) (*credentials.Value, error) {
 		AssumeRoleDuration: time.Hour,
 	}
 
-	kr, err := awsokta.OpenKeyring(nil)
+	kr, err := awsokta.OpenKeyring(conf.GetAWSOktaKeyringBackend())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error opening keyring for credential storage")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -288,7 +288,7 @@ func (c *Config) GetOktaMFAConfig() awsokta.MFAConfig {
 	}
 }
 
-// Gets the keyring backends to be used to store AWS Okta credentials.
+// GetAWSOktaKeyringBackend gets the keyring backends to be used to store AWS Okta credentials.
 // Defaults to an empty list which will select a keyring backend based on OS.
 func (c *Config) GetAWSOktaKeyringBackend() []keyring.BackendType {
 	var backends []keyring.BackendType

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/chanzuckerberg/blessclient/pkg/telemetry"
 	"github.com/chanzuckerberg/blessclient/pkg/util"
@@ -85,13 +86,14 @@ type ClientConfig struct {
 
 // OktaConfig is the Okta config
 type OktaConfig struct {
-	Domain        string  `yaml:"domain"`
-	Organization  string  `yaml:"organization"`
-	Profile       string  `yaml:"profile"`
-	KeyringKeyID  *string `yaml:"keyring_key_id,omitempty"`
-	MFAProvider   *string `yaml:"mfa_provider,omitempty"`
-	MFAFactorType *string `yaml:"mfa_factor_type,omitempty"`
-	DuoDevice     *string `yaml:"duo_device,omitempty"`
+	Domain         string  `yaml:"domain"`
+	Organization   string  `yaml:"organization"`
+	Profile        string  `yaml:"profile"`
+	KeyringKeyID   *string `yaml:"keyring_key_id,omitempty"`
+	MFAProvider    *string `yaml:"mfa_provider,omitempty"`
+	MFAFactorType  *string `yaml:"mfa_factor_type,omitempty"`
+	DuoDevice      *string `yaml:"duo_device,omitempty"`
+	KeyringBackend *string `yaml:"keyring_backend,omitempty"`
 }
 
 // LambdaConfig is the lambda config
@@ -284,6 +286,16 @@ func (c *Config) GetOktaMFAConfig() awsokta.MFAConfig {
 		FactorType: factorType,
 		DuoDevice:  duoDevice,
 	}
+}
+
+// Gets the keyring backends to be used to store AWS Okta credentials.
+// Defaults to an empty list which will select a keyring backend based on OS.
+func (c *Config) GetAWSOktaKeyringBackend() []keyring.BackendType {
+	var backends []keyring.BackendType
+	if c.OktaConfig.KeyringBackend != nil {
+		backends = append(backends, keyring.BackendType(*c.OktaConfig.KeyringBackend))
+	}
+	return backends
 }
 
 // SetAWSUsernameIfMissing queries AWS for the username and sets it in the config if missing


### PR DESCRIPTION
This is introducing feature parity with aws-okta, which allows the backend to be specified for secret storage: https://github.com/segmentio/aws-okta/blob/master/cmd/exec.go#L152

This is required for blessclient with Okta SSO to work on Linux, which requires specific backends.