### PR TITLE
Check certificate freshness before any AWS logic, add config for disabling principal validation of cert

### DIFF
--- a/pkg/bless/client.go
+++ b/pkg/bless/client.go
@@ -80,7 +80,7 @@ func (c *Client) RequestKMSAuthToken(ctx context.Context) (*kmsauth.EncryptedTok
 }
 
 // RequestCert requests a cert
-func (c *Client) RequestCert(ctx context.Context, s *SSH) error {
+func (c *Client) RequestCert(ctx context.Context) error {
 	log.Debugf("Requesting certificate")
 	ctx, span := trace.StartSpan(ctx, "request_cert")
 	defer span.End()
@@ -91,6 +91,11 @@ func (c *Client) RequestCert(ctx context.Context, s *SSH) error {
 		BastionIPs:      strings.Join(c.conf.ClientConfig.BastionIPS, ","),
 		BastionUserIP:   "0.0.0.0/0",
 		Command:         "*",
+	}
+
+	s, err := ssh.NewSSH(c.conf.ClientConfig.SSHPrivateKey)
+	if err != nil {
+		return err
 	}
 
 	log.Debug("Requesting new cert")

--- a/pkg/bless/client_test.go
+++ b/pkg/bless/client_test.go
@@ -138,26 +138,6 @@ func (ts *TestSuite) TestErrOnMalformedCert() {
 	a.Contains(err.Error(), "Could not parse cert")
 }
 
-// If we already have a fresh cert don't request one
-func (ts *TestSuite) TestFreshCert() {
-	t := ts.T()
-	a := assert.New(t)
-	// cert generated as follows:
-	// ssh-keygen -t rsa -f test_key
-	// ssh-keygen -s test_key -I test-cert  -O critical:source-address:0.0.0.0/0 -n test-principal -V -520w:-510w test_key.pub
-	ts.mockKMS.On("EncryptWithContext", mock.Anything).Return(ts.encryptOut, nil)
-	ts.mockLambda.On("InvokeWithContext", mock.Anything).Return(ts.lambdaExecuteOut, nil)
-	certPath := fmt.Sprintf("%s-cert.pub", ts.conf.ClientConfig.SSHPrivateKey)
-	cert, err := ioutil.ReadFile("testdata/cert")
-	a.Nil(err)
-	err = ioutil.WriteFile(certPath, cert, 0644)
-	a.Nil(err)
-	defer os.RemoveAll(certPath)
-	err = ts.client.RequestCert(ts.ctx)
-	a.Nil(err)
-	a.True(ts.mockLambda.Mock.AssertNotCalled(t, "InvokeWithContext"))
-}
-
 func (ts *TestSuite) TestBadPrincipalsCert() {
 	t := ts.T()
 	a := assert.New(t)

--- a/pkg/bless/client_test.go
+++ b/pkg/bless/client_test.go
@@ -123,21 +123,6 @@ func (ts *TestSuite) TestEverythingOk() {
 	a.Nil(err)
 }
 
-// If we can't parse the cert on disk - error
-func (ts *TestSuite) TestErrOnMalformedCert() {
-	t := ts.T()
-	a := assert.New(t)
-
-	certPath := fmt.Sprintf("%s-cert.pub", ts.conf.ClientConfig.SSHPrivateKey)
-	err := ioutil.WriteFile(certPath, []byte("bad cert"), 0644)
-	a.Nil(err)
-	defer os.RemoveAll(certPath)
-
-	err = ts.client.RequestCert(ts.ctx)
-	a.NotNil(err)
-	a.Contains(err.Error(), "Could not parse cert")
-}
-
 func (ts *TestSuite) TestBadPrincipalsCert() {
 	t := ts.T()
 	a := assert.New(t)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,7 +84,7 @@ type ClientConfig struct {
 	BastionIPS []string `yaml:"bastion_ips"`
 	// ask bless to validate existing certs against the remote users
 	// the default is true.
-	ValidatePrincipals *bool `yaml:"validate_principals"`
+	SkipPrincipalValidation bool `yaml:"skip_principal_validation"`
 }
 
 // OktaConfig is the Okta config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,7 +83,7 @@ type ClientConfig struct {
 	// bless calls these bastion ips - your source ip. 0.0.0.0/0 is all
 	BastionIPS []string `yaml:"bastion_ips"`
 	// ask bless to validate existing certs against the remote users
-	// default is true.
+	// the default is true.
 	ValidatePrincipals *bool `yaml:"validate_principals"`
 }
 
@@ -255,6 +255,18 @@ func (c *Config) GetAWSUsername(ctx context.Context, awsClient *cziAWS.Client) (
 		return "", err
 	}
 	return *user.UserName, nil
+}
+
+// GetRemoteUsers gets the list of remote usernames, defaulting to the provided username if
+// the list of configured remote users is empty.
+func (c *Config) GetRemoteUsers(username string) []string {
+	log.Debugf("Getting remote usernames")
+	remoteUsers := c.ClientConfig.RemoteUsers
+	if len(remoteUsers) == 0 {
+		log.Debugf("Defaulting to setting provided username as remote username")
+		remoteUsers = []string{username}
+	}
+	return remoteUsers
 }
 
 // GetOktaMFAConfig gets the user's designated MFA device, defaulting to "phone1"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,9 @@ type ClientConfig struct {
 	RemoteUsers []string `yaml:"remote_users"`
 	// bless calls these bastion ips - your source ip. 0.0.0.0/0 is all
 	BastionIPS []string `yaml:"bastion_ips"`
+	// ask bless to validate existing certs against the remote users
+	// default is true.
+	ValidatePrincipals *bool `yaml:"validate_principals"`
 }
 
 // OktaConfig is the Okta config
@@ -252,18 +255,6 @@ func (c *Config) GetAWSUsername(ctx context.Context, awsClient *cziAWS.Client) (
 		return "", err
 	}
 	return *user.UserName, nil
-}
-
-// GetRemoteUsers gets the list of remote usernames, defaulting to the provided username if
-// the list of configured remote users is empty.
-func (c *Config) GetRemoteUsers(username string) []string {
-	log.Debugf("Getting remote usernames")
-	remoteUsers := c.ClientConfig.RemoteUsers
-	if len(remoteUsers) == 0 {
-		log.Debugf("Defaulting to setting provided username as remote username")
-		remoteUsers = []string{username}
-	}
-	return remoteUsers
 }
 
 // GetOktaMFAConfig gets the user's designated MFA device, defaulting to "phone1"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -169,6 +169,17 @@ func (ts *TestSuite) TestUpdateAWSUsernameEmptyResponse() {
 	a.Contains(err.Error(), "AWS returned nil user")
 }
 
+func (ts *TestSuite) TestGetRemoteUsers() {
+	t := ts.T()
+	a := assert.New(t)
+
+	c, err := config.DefaultConfig()
+	a.Nil(err)
+
+	remoteUsers := c.GetRemoteUsers("testusername")
+	a.Equal([]string{"testusername"}, remoteUsers)
+}
+
 func (ts *TestSuite) TestGetOktaMFADevice() {
 	t := ts.T()
 	a := assert.New(t)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -169,17 +169,6 @@ func (ts *TestSuite) TestUpdateAWSUsernameEmptyResponse() {
 	a.Contains(err.Error(), "AWS returned nil user")
 }
 
-func (ts *TestSuite) TestGetRemoteUsers() {
-	t := ts.T()
-	a := assert.New(t)
-
-	c, err := config.DefaultConfig()
-	a.Nil(err)
-
-	remoteUsers := c.GetRemoteUsers("testusername")
-	a.Equal([]string{"testusername"}, remoteUsers)
-}
-
 func (ts *TestSuite) TestGetOktaMFADevice() {
 	t := ts.T()
 	a := assert.New(t)

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -139,9 +139,9 @@ func (s *SSH) IsCertFresh(c *config.Config) (bool, error) {
 	val, ok := cert.CriticalOptions["source-address"]
 	isFresh = isFresh && ok && val == strings.Join(c.ClientConfig.BastionIPS, ",")
 
-	validatePrinicipals := true
+	validatePrincipals := true
 	if c.ClientConfig.ValidatePrincipals != nil {
-		validatePrincipals = c.ClientConfig.ValidatePrincipals
+		validatePrincipals = *c.ClientConfig.ValidatePrincipals
 	}
 	if validatePrincipals {
 		// Compare principals

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -138,15 +138,7 @@ func (s *SSH) IsCertFresh(c *config.Config) (bool, error) {
 	// TODO: add more validation for certificate critical options
 	val, ok := cert.CriticalOptions["source-address"]
 	isFresh = isFresh && ok && val == strings.Join(c.ClientConfig.BastionIPS, ",")
-
-	validatePrincipals := true
-	if c.ClientConfig.ValidatePrincipals != nil {
-		validatePrincipals = *c.ClientConfig.ValidatePrincipals
-	}
-	if validatePrincipals {
-		// Compare principals
-		isFresh = isFresh && reflect.DeepEqual(cert.ValidPrincipals, c.ClientConfig.RemoteUsers)
-	}
+	isFresh = isFresh && (c.ClientConfig.SkipPrincipalValidation || reflect.DeepEqual(cert.ValidPrincipals, c.ClientConfig.RemoteUsers))
 
 	return isFresh, nil
 }

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -197,7 +197,7 @@ func (ts *TestSuite) TestIsCertFreshExpiredCert() {
 		},
 	}
 	// no error no cert
-	fresh, err := s.IsCertFresh(conf, "username")
+	fresh, err := s.IsCertFresh(conf)
 	a.Nil(err)
 	a.False(fresh)
 }
@@ -217,7 +217,7 @@ func (ts *TestSuite) TestIsCertFreshNoCert() {
 		},
 	}
 	// no error no cert
-	fresh, err := s.IsCertFresh(conf, "username")
+	fresh, err := s.IsCertFresh(conf)
 	a.Nil(err)
 	a.False(fresh)
 }


### PR DESCRIPTION
I refactored the cert freshness to be checked before the AWS client is created.

The reason for this is that engineers often make multiple `scp` or `ssh` calls in the window where a certificate is fresh, and there is no need to setup the AWS client when the lambda does not need to be called.

The positive benefit of this is that when the AWS client is created (and roles are assumed) it runs `sts get-caller-identity` which has a global account rate limit. We can reduce the calls made by SSH if we do the cert fresh check before any AWS related action.

This PR reverts one I submitted earlier: https://github.com/chanzuckerberg/blessclient/pull/100 but on our side it is fine because we don't really expect a user's principal to change between certs, so we are ok to omit this check altogether in the cert freshness check.