### PR TITLE
ensure that vendor stays up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       script:
         - sudo apt update -q
         - sudo apt install -yq libusb-dev libusb-1.0.0-dev
-        - make test
+        - make test-ci
         - bash <(curl -s https://codecov.io/bash)
     - os: osx
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       stage: test
       go: 1.12.x
       script:
-        - make test
+        - make test-ci
     - os: linux
       stage: test
       go: 1.12.x


### PR DESCRIPTION
This will ensure that the vendor directory is always up to date by

1. updating it any time `make test` is run
2. fail if not up to date when `make test-ci` is run