### PR TITLE
[feature] Prepare for Homebrew cutover and new major version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ release:
 
 brews:
   - description: 'SSH without pain.'
-    name: blessclient@1
+    name: blessclient@0
     github:
       owner: chanzuckerberg
       name: homebrew-tap

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,14 +21,6 @@ release:
 
 brews:
   - description: 'SSH without pain.'
-    name: blessclient@2
-    github:
-      owner: chanzuckerberg
-      name: homebrew-tap
-    homepage: 'https://github.com/chanzuckerberg/blessclient'
-    test: system "#{bin}/blessclient version"
-
-  - description: 'SSH without pain.'
     name: blessclient@1
     github:
       owner: chanzuckerberg

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,9 @@ release:
     owner: chanzuckerberg
     name: blessclient
 
-brew:
+brews:
   description: 'SSH without pain.'
+  name: blessclient@2
   github:
     owner: chanzuckerberg
     name: homebrew-tap

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,13 +20,29 @@ release:
     name: blessclient
 
 brews:
-  description: 'SSH without pain.'
-  name: blessclient@2
-  github:
-    owner: chanzuckerberg
-    name: homebrew-tap
-  homepage: 'https://github.com/chanzuckerberg/blessclient'
-  test: system "#{bin}/blessclient version"
+  - description: 'SSH without pain.'
+    name: blessclient@2
+    github:
+      owner: chanzuckerberg
+      name: homebrew-tap
+    homepage: 'https://github.com/chanzuckerberg/blessclient'
+    test: system "#{bin}/blessclient version"
+
+  - description: 'SSH without pain.'
+    name: blessclient@1
+    github:
+      owner: chanzuckerberg
+      name: homebrew-tap
+    homepage: 'https://github.com/chanzuckerberg/blessclient'
+    test: system "#{bin}/blessclient version"
+
+  - description: 'SSH without pain.'
+    name: blessclient
+    github:
+      owner: chanzuckerberg
+      name: homebrew-tap
+    homepage: 'https://github.com/chanzuckerberg/blessclient'
+    test: system "#{bin}/blessclient version"
 
 env_files:
   github_token: ~/.config/goreleaser/github_token

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@
 Inspiration for this project comes from [lyft/python-blessclient](https://github.com/lyft/python-blessclient).
 We decided to write in Go because it is much easier to distribute a statically linked binary to a large team than having to deal with python environments. Some features from [lyft/python-blessclient](https://github.com/lyft/python-blessclient) are currently missing but will be added over time while others are purposefully excluded.
 
+## Versions
+We are currently in the process of releasing a new major version of blessclient that will replace [netflix/bless](https://github.com/Netflix/bless) for a version that relies on federated identity.
+
+### v0.x.x - deprecation notice
+This version will soon be deprecated.
+For the time-being `brew install blessclient` will still point to `v0.x.x`
+
+You can use homebrew to install with
+```
+brew tap chanzuckerberg/tap
+brew install blessclient@0
+```
+
+We will keep a v0 branch around for high priority fixes until migrated fully to `v1.x.x`.
+
+### v1.x.x - in active development
+More to come.
+
 ## Install
 
 ### Mac


### PR DESCRIPTION
In preparation for the new code that relies on federated access (rather than kmsauth + iam keys) I propose we:
- Version homebrew releases `blessclient@0`, `blessclient@1`. For now we keep `blessclient` pointed towards the `blessclient@0` but intend to alias over to `blessclient@1` once we're ready to move everything.

- We cut a v0 branch which will be responsible for `blessclient@0` and the `v0.x.x` code. Probably not much will happen here unless there are high severity issues.