### PR TITLE
Release versioned brew formula blessclient@1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,15 +21,7 @@ release:
 
 brews:
   - description: 'SSH without pain.'
-    name: blessclient@0
-    github:
-      owner: chanzuckerberg
-      name: homebrew-tap
-    homepage: 'https://github.com/chanzuckerberg/blessclient'
-    test: system "#{bin}/blessclient version"
-
-  - description: 'SSH without pain.'
-    name: blessclient
+    name: blessclient@1
     github:
       owner: chanzuckerberg
       name: homebrew-tap


### PR DESCRIPTION
We stop releasing to `blessclient` brew formula until we're ready to make the change for everyone.

Note that this requries goreleaser with commit https://github.com/goreleaser/goreleaser/commit/6645c581141529106751ebdd085781c9cc6034e9 to work properly