### PR TITLE
[feature] Allow specifying a different user for bastion and hosts

### DIFF
--- a/pkg/config/ssh.go
+++ b/pkg/config/ssh.go
@@ -21,8 +21,12 @@ Host {{ .Pattern }}
   User {{ .User }}
 {{ range .Hosts }}
 Host {{ .Pattern }}
-  ProxyJump {{ $bastion.Pattern }}
-  User {{ $bastion.User }}
+	ProxyJump {{ $bastion.Pattern }}
+{{- if .User }}
+	User {{ .User }}
+{{- else }}
+	User {{ $bastion.User }}
+{{- end }}
 {{ end }}{{ end }}
 `
 )
@@ -81,4 +85,5 @@ func (ec *SSHExecCommand) String() string {
 // Host represents a Host block in an ssh config
 type Host struct {
 	Pattern string `yaml:"pattern"`
+	User    string `yaml:"user"`
 }


### PR DESCRIPTION
This would, for example, enable a scenario in which I log into a bastion with a non-privileged user and then log into a protected with some privileged user.