### PR TITLE
[update message] Error message on acquiring lock

### DIFF
--- a/pkg/util/pid_lock.go
+++ b/pkg/util/pid_lock.go
@@ -66,7 +66,7 @@ func (l *Lock) Lock(optBackoff ...backoff.BackOff) error {
 		b = optBackoff[0]
 	}
 
-	return errors.Wrap(backoff.Retry(l.lock.TryLock, b), "Error acquiring lock")
+	return errors.Wrap(backoff.Retry(l.lock.TryLock, b), "Error acquiring lock at ~/.blessclient/.lock")
 }
 
 // Unlock will unlock the pid lockfile


### PR DESCRIPTION
Summary: useful to know where the .lock file is located so you can do
something about it if blessclient fails to acquire the lock