### PR TITLE
BREAKING: Release to blessclient and blessclient@1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,11 +22,19 @@ release:
 brews:
   - description: 'SSH without pain.'
     name: blessclient@1
-    github:
+    tap:
       owner: chanzuckerberg
       name: homebrew-tap
     homepage: 'https://github.com/chanzuckerberg/blessclient'
     test: system "#{bin}/blessclient version"
+  - description: 'SSH without pain.'
+    name: blessclient
+    tap:
+      owner: chanzuckerberg
+      name: homebrew-tap
+    homepage: 'https://github.com/chanzuckerberg/blessclient'
+    test: system "#{bin}/blessclient version"
+
 
 env_files:
   github_token: ~/.config/goreleaser/github_token


### PR DESCRIPTION
NOTE: this will be a breaking change for those relying on `brew install blessclient` installing v0 since it will now install v1. If you want to install v0 then `brew install blessclient@0`